### PR TITLE
Don't package stubs for Linux

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -71,12 +71,11 @@ This project only supports .NET 8 onwards. For older .NET targets please use htt
 
 | Operating system  | _cairo_ shipped with the package | manual installation                                                           |
 |-------------------|----------------------------------|-------------------------------------------------------------------------------|
-| Linux             | (see note for stubs below)       | :heavy_check_mark: (see [downloads](https://www.cairographics.org/download/)) |
-| Windows x64 / x86 | :heavy_check_mark:                | not needed                                                                    |
+| Linux             | :x:                              | :heavy_check_mark: (see [downloads](https://www.cairographics.org/download/)) |
+| Windows x64 / x86 | :heavy_check_mark:               | not needed                                                                    |
 | Mac OS            | :x:                              | :heavy_check_mark: (see [downloads](https://www.cairographics.org/download/)) |
 
 * for Windows x64 / x86 the _cairo_ DLL is bundled with the NuGet package, not further installation needed
-* for Linux x64, arm64, and arm _stubs_ are bundled with the NuGet package, that aid in the lookup for the shared library due to versioning
 
 I don't have Mac OS, thus there are no stubs available, and I can't tell whether it will work or not.
 

--- a/native/ReadMe.md
+++ b/native/ReadMe.md
@@ -6,10 +6,11 @@
 
 For Linux _cairo_ is a prerequisite and must be [installed](https://www.cairographics.org/download/), e.g. for Debian-like:
 ```bash
+sudo apt install libcairo2-bin
+
+# or to install the dev-package (the bin package is sufficient usually)
 sudo apt install libcairo2-dev
 ```
-
-We use [stubs](./stubs/ReadMe.md), which make handling of the versioned _cairo_ library easier.
 
 ### Windows
 

--- a/source/CairoSharp/native.props
+++ b/source/CairoSharp/native.props
@@ -1,5 +1,9 @@
 <Project>
 
+    <PropertyGroup>
+        <UseNativeStubs>false</UseNativeStubs>
+    </PropertyGroup>
+
     <ItemGroup Label="Native cairo DLLs for Windows">
         <CairoWinLib Include="cairo-2" />
         <CairoWinLib Include="fontconfig-1" />
@@ -25,7 +29,9 @@
                  Link="runtimes\win-x86\native\%(FileName).dll"
                  CopyToOutputDirectory="PreserveNewest"
                  PackagePath="runtimes\win-x86\native" />
+    </ItemGroup>
 
+    <ItemGroup Condition="'$(UseNativeStubs)' == 'true'">
         <Content Include="..\..\native\stubs\linux-x64\libcairo.so"
                  LinkBase="runtimes\linux-x64\native"
                  CopyToOutputDirectory="PreserveNewest"


### PR DESCRIPTION
After https://github.com/gfoidl/CairoSharp/pull/6 and https://github.com/gfoidl/CairoSharp/pull/7 the stubs aren't needed anymore, as the so name for Linux is used diretly.